### PR TITLE
Search results to HTML template

### DIFF
--- a/search.go
+++ b/search.go
@@ -21,7 +21,7 @@ type Search struct {
 // ServerHTTP is the HTTP handler for this middleware
 func (s *Search) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	if middleware.Path(r.URL.Path).Matches(s.Config.Endpoint) {
-		if r.Header.Get("Accept") == "application/json" {
+		if r.Header.Get("Accept") == "application/json" || s.Config.Template == nil {
 			return s.SearchJSON(w, r)
 		}
 		return s.SearchHTML(w, r)
@@ -99,7 +99,7 @@ func (s *Search) SearchHTML(w http.ResponseWriter, r *http.Request) (int, error)
 	}
 
 	var buf bytes.Buffer
-	err := s.Template.Execute(&buf, qresults)
+	err := s.Config.Template.Execute(&buf, qresults)
 	if err != nil {
 		return http.StatusInternalServerError, err
 	}


### PR DESCRIPTION
Includes a default template. Needs some sanitization and cleanup work still, but this at least works!

Use like:

```
# Use custom template:
search {
    template ../search_template.html
}

# Default template:
search {
    template
}
```

... Hmm, I just realized that if `template` isn't specified but the request doesn't Accept json, then a server error will occur.
